### PR TITLE
Fix warning on startup

### DIFF
--- a/RegistrationQA/SubjectHierarchyPlugins/qSlicerSubjectHierarchyRegistrationQAPlugin.cxx
+++ b/RegistrationQA/SubjectHierarchyPlugins/qSlicerSubjectHierarchyRegistrationQAPlugin.cxx
@@ -120,7 +120,7 @@ public:
   QMenu* regQAMenu;
   QActionGroup* regQAMenuActionGroup;
   QIcon regQAIcon;
-  vtkSlicerRegistrationQALogic* regQALogic;
+  vtkWeakPointer<vtkSlicerRegistrationQALogic> regQALogic;
 };
 
 //-----------------------------------------------------------------------------
@@ -235,16 +235,18 @@ void qSlicerSubjectHierarchyRegistrationQAPluginPrivate::init()
   convertAction->setActionGroup(this->regQAMenuActionGroup);
   convertAction->setData(QVariant("Convert"));
   this->regQAMenu->addAction(convertAction);
-
-  this->regQALogic = vtkSlicerRegistrationQALogic::New();
-  vtkSmartPointer<vtkMRMLScene> scene; 
-  scene = qSlicerSubjectHierarchyPluginHandler::instance()->mrmlScene();
-  this->regQALogic->SetMRMLScene(scene);
 }
 
 //-----------------------------------------------------------------------------
 qSlicerSubjectHierarchyRegistrationQAPluginPrivate::~qSlicerSubjectHierarchyRegistrationQAPluginPrivate()
 {
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSubjectHierarchyRegistrationQAPlugin::setRegistrationQALogic(vtkSlicerRegistrationQALogic* registrationQALogic)
+{
+  Q_D(qSlicerSubjectHierarchyRegistrationQAPlugin);
+  d->regQALogic = registrationQALogic;
 }
 
 //-----------------------------------------------------------------------------

--- a/RegistrationQA/SubjectHierarchyPlugins/qSlicerSubjectHierarchyRegistrationQAPlugin.h
+++ b/RegistrationQA/SubjectHierarchyPlugins/qSlicerSubjectHierarchyRegistrationQAPlugin.h
@@ -28,6 +28,7 @@
 // #include "qSlicerDicomRtImportExportSubjectHierarchyPluginsExport.h"
 
 class qSlicerSubjectHierarchyRegistrationQAPluginPrivate;
+
 class vtkMRMLNode;
 class vtkMRMLVolumeNode;
 class vtkMRMLAnnotationROINode;
@@ -36,6 +37,8 @@ class vtkMRMLSegmentationNode;
 class vtkMRMLScalarVolumeNode;
 class vtkMRMLTableNode;
 class vtkMRMLRegistrationQANode;
+class vtkSlicerRegistrationQALogic;
+
 //BTX
 /// \ingroup Slicer_QtModules_SubjectHierarchy_Plugins
 class Q_SLICER_REGISTRATIONQA_SUBJECT_HIERARCHY_PLUGINS_EXPORT qSlicerSubjectHierarchyRegistrationQAPlugin : public qSlicerSubjectHierarchyAbstractPlugin
@@ -49,6 +52,9 @@ public:
   virtual ~qSlicerSubjectHierarchyRegistrationQAPlugin();
  
 public:
+  /// Set  module logic.
+  void setRegistrationQALogic(vtkSlicerRegistrationQALogic* registrationQALogic);
+
   /// Determines if a data node can be placed in the hierarchy using the actual plugin,
   /// and gets a confidence value for a certain MRML node (usually the type and possibly attributes are checked).
   /// \param node Node to be added to the hierarchy

--- a/RegistrationQA/qSlicerRegistrationQAModule.cxx
+++ b/RegistrationQA/qSlicerRegistrationQAModule.cxx
@@ -104,9 +104,12 @@ QStringList qSlicerRegistrationQAModule::dependencies() const {
 
 //-----------------------------------------------------------------------------
 void qSlicerRegistrationQAModule::setup() {
-	this->Superclass::setup();
-	// Register Subject Hierarchy core plugins
-       qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(new qSlicerSubjectHierarchyRegistrationQAPlugin());
+  this->Superclass::setup();
+  // Register Subject Hierarchy plugin
+  vtkSlicerRegistrationQALogic* registrationQALogic = vtkSlicerRegistrationQALogic::SafeDownCast(this->logic());
+  qSlicerSubjectHierarchyRegistrationQAPlugin* shPlugin = new qSlicerSubjectHierarchyRegistrationQAPlugin();
+  shPlugin->setRegistrationQALogic(registrationQALogic);
+  qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(shPlugin);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
There was a warning that MRML node type was registered multiple times. THis was caused by the subject hierarchy plugin instantiating an addition module logic class. Loadable modules are expected to have a single module logic class.

Fixed it by passing the module logic object from the module to the subject hierarchy plugin.