### PR TITLE
BUG: Fix links to extension icon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ set(EXTENSION_CATEGORY "Registration")
 set(EXTENSION_CONTRIBUTORS "Kristjan Anderle (GSI), Tobias Brandt (University Clinic of Erlangen), Daniel Richter (University Clinic of Erlangen), Jens Woelfelschneider (University Clinic of Erlangen)")
 set(EXTENSION_DESCRIPTION "Image registration quality assurance tool.")
 set(EXTENSION_STATUS "Beta")
-set(EXTENSION_ICONURL "https://github.com/gsi-biomotion/SlicerRegistrationQA/blob/master/RegQA/Resources/Icons/RegQAIcon.png")
-set(EXTENSION_SCREENSHOTURLS "")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/gsi-biomotion/SlicerRegistrationQA/master/RegistrationQA/Resources/Icons/RegistrationQAIcon.png")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/gsi-biomotion/SlicerRegistrationQA/master/Screenshots/RegQAOverview.png")
 set(EXTENSION_DEPENDS SlicerRT)
 
 #-----------------------------------------------------------------------------

--- a/RegQAExtension.s4ext
+++ b/RegQAExtension.s4ext
@@ -26,7 +26,7 @@ contributors Kristjan Anderle (GSI), Tobias Brandt (University Clinic of Erlange
 category Registration
 
 # url to icon (png, size 128x128 pixels)
-iconurl https://github.com/gsi-biomotion/Slicer-RegQA/blob/master/RegQA/Resources/Icons/RegQAIcon.png
+iconurl https://raw.githubusercontent.com/gsi-biomotion/SlicerRegistrationQA/master/RegistrationQA/Resources/Icons/RegistrationQAIcon.png
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
@@ -36,7 +36,7 @@ status beta
 description Image registration quality assurance tool.
 
 # Space separated list of urls
-screenshoturls http://wiki.slicer.org/slicerWiki/images/4/42/Slicer-r19441-LoadableExtensionTemplate-screenshot.png
+screenshoturls https://raw.githubusercontent.com/gsi-biomotion/SlicerRegistrationQA/master/Screenshots/RegQAOverview.png
 
 # 0 or 1: Define if the extension should be enabled after its installation.
 enabled 1


### PR DESCRIPTION
This fixes invalid icon links causing no image to appear for the extension in Slicer's Extension Manager.

![image](https://user-images.githubusercontent.com/15837524/174422291-01db9b04-01bc-4402-b04e-6011aec26719.png)

cc: @gsi-kanderle 